### PR TITLE
Plan: NAS inventory + AI-assisted cataloging re-architecture

### DIFF
--- a/.claude/phases/PHASE-01-active.md
+++ b/.claude/phases/PHASE-01-active.md
@@ -1,0 +1,24 @@
+# Phase 01 — Inventory
+Status: ACTIVE
+
+## Goal
+Scan the entire NAS read-only and produce a browsable inventory of every file, identified by content hash, tolerant to files being moved or renamed.
+
+## Tasks
+- [ ] Establish the Postgres foundation (supersedes the old SQLite default — see DECISIONS.md, "PostgreSQL over SQLite"): switch `config/database.yml` to PostgreSQL, run Postgres as a Kamal accessory, enable the `pg_trgm` and `pgvector` extensions. Keep the Solid* (cache/queue/cable) stack working.
+- [ ] Mount the NAS read-only on the server; make the root path(s) configurable. The app must never write to the NAS in this phase.
+- [ ] Model the content-addressed inventory: one record per unique content (keyed on checksum) with size, content_type, and triage state; a separate location record (path, mtime, last_seen_at) so the same content can exist at many paths.
+- [ ] Replace the assumption that files are Active Storage attachments: introduce the file-reference model that later phases and `Version` will link to. (Do not yet rip out the existing `has_many_attached :files` — that happens in Phase 03 when linking files to versions.)
+- [ ] Scanner background job (Solid Queue): walk the tree, stream-checksum each file (only re-hash when size/mtime changed), upsert content by checksum, upsert location by path, stamp last_seen_at. Idempotent and re-runnable.
+- [ ] Detect locations not seen in the latest run → mark as moved/deleted rather than dropping the catalog entry.
+- [ ] Inventory dashboard: total volume, counts by format, counts by top-level folder, and exact-duplicate list (content present at more than one location).
+- [ ] Tests: scanner populates correctly; re-running after moving a file updates the location without duplicating the content record; dashboard counts are accurate.
+
+## Acceptance Criteria
+- Running the scanner on a representative subtree fully populates the inventory.
+- Moving a file on the NAS and re-scanning updates its location and does not create a second content record.
+- The dashboard shows accurate format/folder counts and a correct exact-duplicate list.
+- The app provably never writes to the NAS during this phase.
+
+## Decisions Made This Phase
+(append as you go)

--- a/.claude/phases/PHASE-02-pending.md
+++ b/.claude/phases/PHASE-02-pending.md
@@ -1,0 +1,20 @@
+# Phase 02 — Content extraction & full-text search
+Status: PENDING
+
+## Goal
+Extract the text of every supported file and make the whole corpus full-text searchable — before any manual cataloging — including Tibetan regardless of input method.
+
+## Tasks
+- [ ] Per-format extraction: PDF (pdf-reader, already a dependency), Word/docx, and a decision on image OCR (adopt an OCR tool or defer images to a later pass). Store extracted text on the content record.
+- [ ] Extraction background job: resumable, tracks status per file (pending / done / failed / unsupported); failures are logged and visible, never silent.
+- [ ] SQLite FTS5 index over extracted text + filename, returning result snippets.
+- [ ] Tibetan search: index Unicode + Wylie + phonetic forms so a query in any one method finds the file. Note: the existing converters are client-side JS via CDN — running them server-side (JS runtime) or finding Ruby equivalents is a real sub-task to scope here.
+- [ ] Search UI over the inventory (filename + content) with snippets, usable before cataloging exists.
+
+## Acceptance Criteria
+- Full-text search returns relevant files by their content, not just filename.
+- A Tibetan query finds matching files whether typed in Unicode, Wylie, or phonetics.
+- Extraction failures are surfaced in the UI/dashboard, not swallowed.
+
+## Decisions Made This Phase
+(append as you go)

--- a/.claude/phases/PHASE-03-pending.md
+++ b/.claude/phases/PHASE-03-pending.md
@@ -1,0 +1,21 @@
+# Phase 03 — AI-assisted triage & cataloging
+Status: PENDING
+
+## Goal
+For each un-catalogued file, have Claude propose catalog metadata and near-duplicate links; a human confirms or corrects each suggestion into the Text → Translation → Version model.
+
+## Tasks
+- [ ] Integrate the Claude API with tiered models: cheap model for bulk triage, strong model for ambiguous cases.
+- [ ] Per-file proposal: prayer identity, language, title (Tibetan / Wylie / phonetic), candidate master/deity/school, with a confidence signal.
+- [ ] Near-duplicate clustering via embeddings (same prayer, different wording — what checksums cannot catch).
+- [ ] Review-queue UI: show the AI proposal, let the human confirm/edit, then create or link Text → Translation → Version and mark the file as catalogued (set its version reference). Reuse the existing text/curation form.
+- [ ] Rework `Version` to reference indexed files instead of `has_many_attached :files`; keep Active Storage only for derived covers/thumbnails (reuse `ExtractPdfCover`).
+- [ ] Tests covering: file goes from untriaged → linked to a Version; near-duplicate clusters surface; nothing is auto-committed without human confirmation.
+
+## Acceptance Criteria
+- A file can move from "untriaged" to "linked to a Version" in a few clicks.
+- Near-duplicate clusters are surfaced to the reviewer.
+- The human is always in the loop — no metadata enters the catalog without confirmation.
+
+## Decisions Made This Phase
+(append as you go)

--- a/.claude/phases/PHASE-04-pending.md
+++ b/.claude/phases/PHASE-04-pending.md
@@ -1,0 +1,19 @@
+# Phase 04 — Efficient faceted search
+Status: PENDING
+
+## Goal
+Deliver the "find a prayer instantly knowing it is linked to a master or a deity" experience: faceted, fast, combining catalog metadata with full-text.
+
+## Tasks
+- [ ] Facets: master/author, deity, school, language, format — combinable.
+- [ ] Combine catalogued metadata with the FTS5 full-text index in a single result flow.
+- [ ] Pagination and result ranking; ensure performance on the full corpus (no loading all results into memory — the current search does this).
+- [ ] Clear result presentation across the result types (catalogued texts vs raw inventory files).
+
+## Acceptance Criteria
+- A prayer can be found quickly by filtering on its master and/or deity.
+- Results are paginated and remain responsive on the full corpus.
+- Search spans both fully catalogued items and not-yet-catalogued inventory files.
+
+## Decisions Made This Phase
+(append as you go)

--- a/.claude/phases/PHASE-05-pending.md
+++ b/.claude/phases/PHASE-05-pending.md
@@ -1,0 +1,26 @@
+# Phase 05 — Naming convention & reversible physical reorganization
+Status: PENDING
+
+## Goal
+Design a canonical path convention, generate target paths from confirmed metadata, and (only if still warranted) apply physical moves safely and reversibly.
+
+## Precondition
+Do not start until the catalog from phases 1–4 has been used for real and we have confirmed a physical reorganization is still needed. The catalog may make a large move unnecessary.
+
+## Tasks
+- [ ] Design the path convention with Claude at the *aggregate* level (clusters, naming rules, ambiguous cases) — fed by the metadata already extracted, not file-by-file.
+- [ ] Path generator: derive a canonical path deterministically from a file's confirmed metadata, so the tree becomes a projection of the database.
+- [ ] Dry-run planner: produce a reviewable "old path → new path" plan that moves nothing.
+- [ ] Reversible batched mover: full move log (checksum + old path → new path), backup/snapshot of the old structure kept until validated, batches not big-bang.
+- [ ] Package-aware moves: InDesign/QuarkXPress files moved together with their linked assets so documents don't break.
+- [ ] Decide and grant the app write access to the NAS (reverses the Phase 01 read-only stance) — log it as its own decision.
+- [ ] New-file intake (steady state): drag-and-drop in the web UI → AI proposes metadata + canonical path → human confirms once.
+
+## Acceptance Criteria
+- The dry-run produces a complete, reviewable move plan with nothing moved.
+- Applying the plan is fully reversible from the move log.
+- Moved InDesign/QuarkXPress documents still open with their links intact.
+- New files dropped in the UI get an AI-proposed placement the human can accept or edit.
+
+## Decisions Made This Phase
+(append as you go)

--- a/.claude/phases/PHASE-06-pending.md
+++ b/.claude/phases/PHASE-06-pending.md
@@ -1,0 +1,11 @@
+# Phase 06 — Editorial platform (FUTURE — out of scope for now)
+Status: PENDING
+
+## Goal
+Line-by-line indexed texts aligned across Tibetan / French / English / Sanskrit, and semi-automatic prayer-booklet generation (select prayers, compile into booklets).
+
+## Note
+This is the long-term direction, explicitly deferred. Prototypes already exist and the requirements are largely known. It is recorded here only so the earlier phases do not foreclose it. It hooks in *below* the `Version` (a Version's content is segmented into aligned lines). No design or tasks are committed now — this phase is opened only after the catalog (phases 1–5) is delivered and stable.
+
+## Decisions Made This Phase
+(append as you go)

--- a/DECISIONS.md
+++ b/DECISIONS.md
@@ -1,0 +1,89 @@
+# Decisions
+
+Architecture decisions for Padmakara-Find. Append-only. Do not edit past entries — add a new one if something changes.
+
+---
+
+## 2026-06-02 — NAS is the single source of truth; the app indexes, it does not store
+**Chosen:** The prayer files live only on the NAS. The application is a catalog/index that *points to* files on the NAS. It never copies the originals into its own storage.
+**Alternatives:** Make the app the system of record (import every file into Active Storage / object storage), as the current code does via `Version has_many_attached :files`.
+**Why:** User decision. There must be exactly one place where a file exists, to avoid divergence between a "NAS copy" and an "app copy". Re-uploading tens of thousands of files by hand is also unrealistic.
+**Trade-offs:** The app depends on the NAS being mounted and reachable. The app cannot guarantee a file hasn't changed underneath it between scans (mitigated by checksums). Existing `has_many_attached :files` on `Version` must be replaced by references to indexed files.
+**Revisit if:** We ever need the app to serve files when the NAS is offline, or need an immutable archival copy independent of the NAS.
+
+---
+
+## 2026-06-02 — File identity is its content hash, not its path
+**Chosen:** A file's identity is the checksum of its content. The path is a mutable "current location" attribute. The catalog is keyed on content (checksum); locations point at it.
+**Alternatives:** Key the catalog on the file path (the obvious approach when "the app points to the NAS").
+**Why:** The NAS will be reorganized (files moved) in parallel with cataloging. If the catalog were keyed on path, every move would break its entry. Content-addressing (like Git) makes the catalog survive any move: a re-scan sees the same hash at a new path and just updates the location. It also yields exact-duplicate detection for free — a known pain point ("we don't know which is the latest version").
+**Trade-offs:** Checksumming tens of thousands of files is I/O-heavy (streamed, run as background jobs, only re-hash when size/mtime changes). The same content at multiple paths needs a one-content → many-locations model.
+**Revisit if:** Checksum collisions or hashing cost ever become a practical problem (not expected with a modern hash).
+
+---
+
+## 2026-06-02 — The database is the organization; the folder tree is only physical storage
+**Chosen:** The multi-faceted catalog (master/deity/school/language/tag + full-text) is the real organization. The NAS folder tree is just storage and only needs to be *consistent and predictable*, not semantically perfect. Where a physical convention is adopted, canonical paths are *generated from* confirmed metadata so the tree becomes a projection of the database.
+**Alternatives:** Invest heavily in designing one "perfect" folder hierarchy and move everything into it.
+**Why:** A folder tree can only express one axis at a time, but a prayer is legitimately linked to a master AND a deity AND a school AND a language AND a collection. Any single tree makes the other axes second-class. The database resolves this natively; the tree cannot. So effort goes into the catalog, not into chasing an ideal tree the database makes unnecessary.
+**Trade-offs:** Humans browsing the NAS directly (Finder, InDesign) still benefit from a clean tree, so we don't abandon it — we generate it deterministically instead of hand-maintaining it.
+**Revisit if:** A workflow emerges that genuinely needs a hand-curated hierarchy the generated convention can't express.
+
+---
+
+## 2026-06-02 — Defer the physical mass-move until the catalog has proven itself; make it reversible
+**Chosen:** Build the inventory + catalog + search and *use it for real* before moving any files physically. When/if we do move, it is dry-run first, batched, fully logged (checksum + old path → new path), with a backup of the old structure kept until validated, and InDesign/QuarkXPress files moved together with their linked assets as packages.
+**Alternatives:** Reorganize the NAS up front, then build the catalog on the clean tree.
+**Why:** Moving a 20-year archive of tens of thousands of files is the single highest-risk, hardest-to-reverse operation in the project. InDesign/QuarkXPress documents reference linked images and fonts by path — moving them blindly breaks documents. Content-addressing protects the *catalog* during a move, but not the *files' internal links*. We may also discover the catalog makes a large physical reorg unnecessary.
+**Trade-offs:** The NAS stays messy for humans browsing it directly during phases 1–4. Accepted: findability is delivered by the app in the meantime.
+**Revisit if:** Direct-on-NAS browsing becomes a blocking pain before the catalog is mature.
+
+---
+
+## 2026-06-02 — Keep SQLite; use FTS5 for full-text search
+**Chosen:** Stay on SQLite. Use its built-in FTS5 extension for full-text search over extracted content and metadata.
+**Alternatives:** Migrate to PostgreSQL (+ pg_search); add Elasticsearch/Solr.
+**Why:** This is an internal editorial tool with few concurrent writers. SQLite comfortably handles tens of thousands of records; its only real limit is concurrent writes, which this workload doesn't stress. FTS5 gives strong full-text search with zero new infrastructure. Adding Postgres/Elasticsearch now is ops complexity for no current benefit.
+**Trade-offs:** No semantic ranking out of the box; concurrent-write ceiling; FTS5 tokenization needs care for Tibetan.
+**Revisit if:** We get many simultaneous editors, or search needs outgrow FTS5 (e.g. cross-language semantic search at scale → consider embeddings/vector search, see Phase 3).
+
+---
+
+## 2026-06-02 — AI-assisted triage, always human-in-the-loop
+**Chosen:** Use Claude to read extracted content and *propose* catalog metadata (prayer identity, language, title, master/deity/school) and flag near-duplicates. A human confirms or corrects every suggestion before it enters the catalog. Tier models: cheap (Haiku) for bulk, strong (Opus) for ambiguous cases.
+**Alternatives:** Fully manual cataloging; or fully automated AI cataloging with no review.
+**Why:** Manual cataloging of tens of thousands of files won't scale; fully automated filing of a religious archive is unacceptable for accuracy and trust. AI proposes, human disposes — best of both, and it reuses the existing curation form.
+**Trade-offs:** API cost; the review queue is still real human work (but vastly less than from-scratch entry).
+**Revisit if:** AI proposals prove either reliable enough to batch-approve, or too noisy to be worth reviewing.
+
+---
+
+## 2026-06-02 — Active Storage is demoted to a cache for derived artifacts only
+**Chosen:** Active Storage is kept only for *derived* data the app generates (PDF cover thumbnails, previews). Original files are never stored in it. References to original files move to the new content-addressed file model.
+**Alternatives:** Keep using `has_many_attached :files` for originals.
+**Why:** Follows from "NAS is the single source of truth". Thumbnails/covers are regenerable, so caching them locally doesn't violate the single-source rule. The existing `ExtractPdfCover` service is reused almost as-is.
+**Trade-offs:** The current upload/attach flow on `Version` must be reworked to reference indexed files instead of attaching copies.
+**Revisit if:** We decide the app should also archive originals (would reverse the source-of-truth decision).
+
+---
+
+## 2026-06-02 — PostgreSQL over SQLite; all search stays in Postgres (supersedes "Keep SQLite; use FTS5")
+**Chosen:** PostgreSQL as the database. Full-text search via `tsvector`/`ts_rank`, fuzzy/typo-tolerant matching via `pg_trgm`, and vector/semantic search via `pgvector` — all inside Postgres. No separate search engine.
+**Alternatives:** SQLite + FTS5 (the earlier decision, 2026-06-02); adding Elasticsearch or another dedicated search engine.
+**Why:** As scope solidified, three factors outweighed SQLite's operational simplicity: (1) embeddings are central to Phase 3 (near-duplicate detection, later cross-language semantic search) and `pgvector` keeps vectors in the same DB; (2) the "extremely efficient search" goal wants fuzzy matching (`pg_trgm`) and ranked full-text (`tsvector`), both stronger than FTS5; (3) ingestion is write-heavy in bursts (parallel scan + extraction workers), which Postgres handles without SQLite's single-writer serialization. Ops cost is low: Kamal runs Postgres as an accessory container on the same on-prem box. Elasticsearch is rejected as overkill — the corpus is tens of thousands of docs (orders of magnitude below where ES earns its complexity), it adds a heavy JVM service plus a sync pipeline, and it solves neither hard problem (Tibetan tokenization, semantic matching).
+**Trade-offs:** One more container to run and back up. The database becomes the most precious asset (curated human work) and needs its own backup (nightly `pg_dump` + off-box copy), independent of the NAS. Tibetan still needs custom tokenization regardless of engine.
+**Revisit if:** Search genuinely outgrows Postgres (millions of docs / heavy concurrent query load) — then evaluate a lightweight modern engine (Meilisearch/Typesense) before Elasticsearch.
+
+---
+
+## 2026-06-02 — On-prem application server with LAN-only NAS access
+**Chosen:** Run the app on a small on-prem server inside the local network. It mounts the NAS over the LAN and is the only system that touches it; the NAS is never exposed to the internet. Any remote access goes to the app (behind VPN / authenticated reverse proxy), never to the NAS. Target spec: ~4 modern cores, 16 GB RAM, NVMe SSD (~500 GB, for OS/app/DB/thumbnail cache only — originals stay on the NAS), gigabit wired link to the NAS, Linux + Docker/Kamal, no GPU (AI via API).
+**Alternatives:** Cloud-hosted app; exposing the NAS directly; a heavily-specced server.
+**Why:** User decision on hosting. Keeps the NAS off the public internet by design. The workload is light except for bursty one-off ingestion (I/O-bound NAS reads + extraction/OCR), so standard hardware suffices; the real bottleneck is the NAS↔server network, not CPU. Running AI via API avoids needing a GPU or large RAM for local models.
+**Trade-offs:** The app depends on sharing the NAS's network; remote work needs a VPN. A heavier future (local OCR/embeddings at scale, an editorial platform with many concurrent editors) may warrant more RAM/CPU later.
+**Revisit if:** Ingestion is unacceptably slow (check the NAS link first), or local AI / large concurrent editing is adopted.
+
+---
+
+## Future direction (not a decision yet — recorded for foresight)
+A second-stage editorial platform is intended: line-by-line indexed texts aligned across Tibetan / French / English / Sanskrit, and semi-automatic prayer-booklet generation (select prayers, compile). Prototypes already exist. This is **out of scope** for the catalog work. It will hook in *below* the `Version` (a Version's content gets segmented into aligned lines). Keeping `Version` as the content anchor is enough to avoid foreclosing it; no further design is done now.


### PR DESCRIPTION
## What this is

Planning artifacts only — no code changes. Establishes the agreed direction before a junior developer picks up implementation.

Reframes the project from a **manual CRUD catalog** (where files are re-uploaded by hand into Active Storage) into a **NAS inventory + AI-assisted cataloging system**, because the hard part of the real problem — making sense of tens of thousands of accumulated, messy, multi-format prayer files — was unbuilt.

## Contents

- **`DECISIONS.md`** — 9 decisions (append-only format):
  - NAS = single source of truth; the app indexes, never copies
  - File identity = content checksum, not path (survives NAS reorganization)
  - The database is the organization; the folder tree is only physical storage
  - Physical mass-move deferred, reversible, batched
  - PostgreSQL + `pgvector`/`pg_trgm`/`tsvector` (no Elasticsearch)
  - AI-assisted triage, always human-in-the-loop
  - Active Storage demoted to a cache for derived artifacts (thumbnails/covers)
  - On-prem LAN-only server (NAS never exposed to the internet)
- **`.claude/phases/`** — 6-phase plan, **Phase 01 (Inventory) active**:
  1. Inventory (scanner, content-addressed model, dashboard, exact-dup detection) ← active
  2. Content extraction + full-text search
  3. AI-assisted triage & cataloging
  4. Efficient faceted search
  5. Naming convention + reversible physical reorganization
  6. Editorial platform (future, out of scope)

## How to use

Review the first four decisions in `DECISIONS.md` (the foundations). Merge to make this the baseline, then implementation starts from Phase 01.

🤖 Generated with [Claude Code](https://claude.com/claude-code)